### PR TITLE
Allow preResponseCallback and preResponseChunkCallback to return void

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,14 @@ declare module 'fastify' {
     ai: {
       warp: (request: FastifyRequest, prompt: string) => Promise<string>
       warpStream: (request: FastifyRequest, prompt: string) => Promise<ReadableStream>
-      preResponseCallback?: ((request: FastifyRequest, response: string) => string) | ((request: FastifyRequest, response: string) => Promise<string>)
-      preResponseChunkCallback?: ((request: FastifyRequest, response: string) => string) | ((request: FastifyRequest, response: string) => Promise<string>)
+      preResponseCallback?: ((request: FastifyRequest, response: string) => void) |
+      ((request: FastifyRequest, response: string) => string) |
+      ((request: FastifyRequest, response: string) => Promise<void>) |
+      ((request: FastifyRequest, response: string) => Promise<string>)
+      preResponseChunkCallback?: ((request: FastifyRequest, response: string) => void) |
+      ((request: FastifyRequest, response: string) => string) |
+      ((request: FastifyRequest, response: string) => Promise<void>) |
+      ((request: FastifyRequest, response: string) => Promise<string>)
       rateLimiting: {
         max?: ((req: FastifyRequest, key: string) => number) | ((req: FastifyRequest, key: string) => Promise<number>)
         allowList?: (req: FastifyRequest, key: string) => boolean | Promise<boolean>

--- a/plugins/warp.ts
+++ b/plugins/warp.ts
@@ -39,7 +39,7 @@ export default fastifyPlugin(async (fastify) => {
 
       let response = await provider.ask(decoratedPrompt)
       if (fastify.ai.preResponseCallback !== undefined) {
-        response = await fastify.ai.preResponseCallback(request, response)
+        response = await fastify.ai.preResponseCallback(request, response) ?? response
       }
 
       return response
@@ -57,7 +57,7 @@ export default fastifyPlugin(async (fastify) => {
           if (fastify.ai.preResponseChunkCallback === undefined) {
             return response
           }
-          return await fastify.ai.preResponseChunkCallback(request, response)
+          return await fastify.ai.preResponseChunkCallback(request, response) ?? response
         }
       }
 


### PR DESCRIPTION
This covers two use cases:
 * safe guard for if dev is using javascript and forgets to `return response`
 * dev isn't modifying the response in the callbacks, makes it a little bit nicer to use