### PR TITLE
Make build output esm

### DIFF
--- a/ai-providers/ollama.ts
+++ b/ai-providers/ollama.ts
@@ -1,7 +1,7 @@
 import { ReadableStream, UnderlyingByteSource, ReadableByteStreamController } from 'stream/web'
 import { Ollama, ChatResponse } from 'ollama'
-import { AiProvider, StreamChunkCallback } from './provider'
-import { AiStreamEvent, encodeEvent } from './event'
+import { AiProvider, StreamChunkCallback } from './provider.js'
+import { AiStreamEvent, encodeEvent } from './event.js'
 
 type OllamaStreamResponse = AsyncGenerator<ChatResponse>
 

--- a/ai-providers/open-ai.ts
+++ b/ai-providers/open-ai.ts
@@ -1,10 +1,10 @@
 import { ReadableStream, UnderlyingByteSource, ReadableByteStreamController } from 'node:stream/web'
 import OpenAI from 'openai'
-import { AiProvider, NoContentError, StreamChunkCallback } from './provider'
+import { AiProvider, NoContentError, StreamChunkCallback } from './provider.js'
 import { ReadableStream as ReadableStreamPolyfill } from 'web-streams-polyfill'
 import { fetch } from 'undici'
-import { ChatCompletionChunk } from 'openai/resources/index.mjs'
-import { AiStreamEvent, encodeEvent } from './event'
+import { ChatCompletionChunk } from 'openai/resources/index'
+import { AiStreamEvent, encodeEvent } from './event.js'
 import createError from '@fastify/error'
 
 const InvalidTypeError = createError<string>('DESERIALIZING_ERROR', 'Deserializing error: %s', 500)
@@ -125,6 +125,6 @@ export class OpenAiProvider implements AiProvider {
       ],
       stream: true
     })
-    return new ReadableStream(new OpenAiByteSource(response.toReadableStream(), chunkCallback))
+    return new ReadableStream(new OpenAiByteSource(response.toReadableStream() as ReadableStreamPolyfill, chunkCallback))
   }
 }

--- a/cli/create.ts
+++ b/cli/create.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { join } from 'node:path'
 import { parseArgs } from 'node:util'
-import { Generator } from '../lib/generator'
+import { Generator } from '../lib/generator.js'
 
 async function execute (): Promise<void> {
   const args = parseArgs({

--- a/cli/start.ts
+++ b/cli/start.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import stackable from '../index'
+import stackable from '../index.js'
 import { start } from '@platformatic/service'
 import { printAndExitLoadConfigError } from '@platformatic/config'
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { ReadableStream } from 'node:stream/web'
 import { PlatformaticApp } from '@platformatic/service'
 import { errorResponseBuilderContext } from '@fastify/rate-limit'
-import { AiWarpConfig } from './config'
+import { AiWarpConfig } from './config.js'
 
 declare module 'fastify' {
   interface FastifyInstance {

--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,17 @@
 import { platformaticService, Stackable } from '@platformatic/service'
 import fastifyUser from 'fastify-user'
 import fastifyPlugin from 'fastify-plugin'
-import { schema } from './lib/schema'
-import { Generator } from './lib/generator'
-import { AiWarpConfig } from './config'
-import warpPlugin from './plugins/warp'
-import authPlugin from './plugins/auth'
-import apiPlugin from './plugins/api'
-import rateLimitPlugin from './plugins/rate-limiting'
+import { schema } from './lib/schema.js'
+import { Generator } from './lib/generator.js'
+import { AiWarpConfig } from './config.js'
+import warpPlugin from './plugins/warp.js'
+import authPlugin from './plugins/auth.js'
+import apiPlugin from './plugins/api.js'
+import rateLimitPlugin from './plugins/rate-limiting.js'
 
 const stackable: Stackable<AiWarpConfig> = async function (fastify, opts) {
   const { config } = fastify.platformatic
-  await fastify.register(fastifyUser, config.auth)
+  await fastify.register(fastifyUser as any, config.auth)
   await fastify.register(authPlugin, opts)
 
   await fastify.register(warpPlugin, opts) // needs to be registered here for fastify.ai to be decorated

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -2,9 +2,9 @@ import { join } from 'node:path'
 import { readFile } from 'node:fs/promises'
 import { Generator as ServiceGenerator } from '@platformatic/service'
 import { BaseGenerator } from '@platformatic/generators'
-import { schema } from './schema'
-import { generateGlobalTypesFile } from './templates/types'
-import { generatePluginWithTypesSupport } from '@platformatic/generators/lib/create-plugin'
+import { schema } from './schema.js'
+import { generateGlobalTypesFile } from './templates/types.js'
+import { generatePlugins } from '@platformatic/generators/lib/create-plugin.js'
 
 interface PackageJson {
   name: string
@@ -22,7 +22,7 @@ class AiWarpGenerator extends ServiceGenerator {
       // TODO: temporary fix, when running the typescript files directly
       //  (in tests) this goes a directory above the actual project. Exposing
       //  temporarily until I come up with something better
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json')
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json')
     }
     return Object.assign({}, defaultBaseConfig, defaultConfig)
   }
@@ -147,7 +147,10 @@ class AiWarpGenerator extends ServiceGenerator {
     })
 
     if (this.config.plugin !== undefined && this.config.plugin) {
-      this.addFile(generatePluginWithTypesSupport(this.config.typescript ?? false))
+      const plugins = generatePlugins(this.config.typescript ?? false)
+      for (const plugin of plugins) {
+        this.addFile(plugin)
+      }
     }
   }
 

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -290,6 +290,6 @@ const aiWarpSchema = {
 
 export { aiWarpSchema as schema }
 
-if (require.main === module) {
+if (process.argv.length > 2 && process.argv[2] === '--dump-schema') {
   console.log(JSON.stringify(aiWarpSchema, null, 2))
 }

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "@platformatic/ai-warp",
   "version": "0.0.1",
   "main": "dist/index.js",
+  "type": "module",
   "bin": {
     "create-ai-warp": "./dist/cli/create.js",
     "start-ai-warp": "./dist/cli/start.js"
   },
   "scripts": {
     "build": "tsc --build",
-    "build:config": "node ./dist/lib/schema.js | json2ts > config.d.ts",
+    "build:config": "node ./dist/lib/schema.js --dump-schema | json2ts > config.d.ts",
     "clean": "rm -fr ./dist",
     "lint": "ts-standard | snazzy",
     "lint:fix": "ts-standard --fix | snazzy",

--- a/plugins/rate-limiting.ts
+++ b/plugins/rate-limiting.ts
@@ -4,7 +4,7 @@ import { FastifyInstance } from 'fastify'
 import createError from '@fastify/error'
 import fastifyPlugin from 'fastify-plugin'
 import fastifyRateLimit from '@fastify/rate-limit'
-import { AiWarpConfig } from '../config'
+import { AiWarpConfig } from '../config.js'
 
 interface RateLimitMax {
   // One claim to many values & maxes

--- a/plugins/warp.ts
+++ b/plugins/warp.ts
@@ -1,13 +1,13 @@
 // eslint-disable-next-line
 /// <reference path="../index.d.ts" />
 import fastifyPlugin from 'fastify-plugin'
-import { OpenAiProvider } from '../ai-providers/open-ai'
+import { OpenAiProvider } from '../ai-providers/open-ai.js'
 import { MistralProvider } from '../ai-providers/mistral.js'
-import { AiProvider, StreamChunkCallback } from '../ai-providers/provider'
-import { AiWarpConfig } from '../config'
+import { AiProvider, StreamChunkCallback } from '../ai-providers/provider.js'
+import { AiWarpConfig } from '../config.js'
 import createError from '@fastify/error'
-import { OllamaProvider } from '../ai-providers/ollama'
-import { AzureProvider } from '../ai-providers/azure'
+import { OllamaProvider } from '../ai-providers/ollama.js'
+import { AzureProvider } from '../ai-providers/azure.js'
 
 const UnknownAiProviderError = createError('UNKNOWN_AI_PROVIDER', 'Unknown AI Provider')
 

--- a/tests/e2e/api.test.ts
+++ b/tests/e2e/api.test.ts
@@ -3,11 +3,11 @@ import { before, after, describe, it } from 'node:test'
 import assert from 'node:assert'
 import { FastifyInstance } from 'fastify'
 import fastifyPlugin from 'fastify-plugin'
-import { AiWarpConfig } from '../../config'
-import { buildAiWarpApp } from '../utils/stackable'
-import { AZURE_DEPLOYMENT_NAME, AZURE_MOCK_HOST } from '../utils/mocks/azure'
-import { MOCK_CONTENT_RESPONSE, buildExpectedStreamBodyString } from '../utils/mocks/base'
-import { OLLAMA_MOCK_HOST } from '../utils/mocks/ollama'
+import { AiWarpConfig } from '../../config.js'
+import { buildAiWarpApp } from '../utils/stackable.js'
+import { AZURE_DEPLOYMENT_NAME, AZURE_MOCK_HOST } from '../utils/mocks/azure.js'
+import { MOCK_CONTENT_RESPONSE, buildExpectedStreamBodyString } from '../utils/mocks/base.js'
+import { OLLAMA_MOCK_HOST } from '../utils/mocks/ollama.js'
 
 const expectedStreamBody = buildExpectedStreamBodyString()
 

--- a/tests/e2e/auth.test.ts
+++ b/tests/e2e/auth.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { it } from 'node:test'
 import assert from 'node:assert'
-import { buildAiWarpApp } from '../utils/stackable'
-import { AiWarpConfig } from '../../config'
-import { authConfig, createToken } from '../utils/auth'
+import { buildAiWarpApp } from '../utils/stackable.js'
+import { AiWarpConfig } from '../../config.js'
+import { authConfig, createToken } from '../utils/auth.js'
 
 const aiProvider: AiWarpConfig['aiProvider'] = {
   openai: {

--- a/tests/e2e/index.ts
+++ b/tests/e2e/index.ts
@@ -1,6 +1,6 @@
 import './api.test'
 import './rate-limiting.test'
 import './auth.test'
-import { mockAllProviders } from '../utils/mocks'
+import { mockAllProviders } from '../utils/mocks/index.js'
 
 mockAllProviders()

--- a/tests/e2e/rate-limiting.test.ts
+++ b/tests/e2e/rate-limiting.test.ts
@@ -2,9 +2,9 @@
 import { it } from 'node:test'
 import assert from 'node:assert'
 import fastifyPlugin from 'fastify-plugin'
-import { AiWarpConfig } from '../../config'
-import { buildAiWarpApp } from '../utils/stackable'
-import { authConfig, createToken } from '../utils/auth'
+import { AiWarpConfig } from '../../config.js'
+import { buildAiWarpApp } from '../utils/stackable.js'
+import { authConfig, createToken } from '../utils/auth.js'
 
 const aiProvider: AiWarpConfig['aiProvider'] = {
   openai: {

--- a/tests/types/fastify.test-d.ts
+++ b/tests/types/fastify.test-d.ts
@@ -2,7 +2,7 @@ import { ReadableStream } from 'node:stream/web'
 import { FastifyInstance, FastifyRequest } from 'fastify'
 import { errorResponseBuilderContext } from '@fastify/rate-limit'
 import { expectAssignable } from 'tsd'
-import '../../index.d'
+import '../../index.js'
 
 expectAssignable<FastifyInstance['ai']['warp']>(async (_: FastifyRequest, _2: string) => '')
 

--- a/tests/types/schema.test-d.ts
+++ b/tests/types/schema.test-d.ts
@@ -1,5 +1,5 @@
 import { expectAssignable } from 'tsd'
-import { AiWarpConfig } from '../../config'
+import { AiWarpConfig } from '../../config.js'
 
 expectAssignable<AiWarpConfig['aiProvider']>({
   openai: {

--- a/tests/unit/ai-providers.test.ts
+++ b/tests/unit/ai-providers.test.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { MistralProvider } from '../../ai-providers/mistral'
-import { OpenAiProvider } from '../../ai-providers/open-ai'
-import { AiProvider } from '../../ai-providers/provider'
-import { OllamaProvider } from '../../ai-providers/ollama'
-import { AzureProvider } from '../../ai-providers/azure'
-import { MOCK_CONTENT_RESPONSE, buildExpectedStreamBodyString } from '../utils/mocks/base'
-import { OLLAMA_MOCK_HOST } from '../utils/mocks/ollama'
-import { AZURE_DEPLOYMENT_NAME, AZURE_MOCK_HOST } from '../utils/mocks/azure'
+import { MistralProvider } from '../../ai-providers/mistral.js'
+import { OpenAiProvider } from '../../ai-providers/open-ai.js'
+import { AiProvider } from '../../ai-providers/provider.js'
+import { OllamaProvider } from '../../ai-providers/ollama.js'
+import { AzureProvider } from '../../ai-providers/azure.js'
+import { MOCK_CONTENT_RESPONSE, buildExpectedStreamBodyString } from '../utils/mocks/base.js'
+import { OLLAMA_MOCK_HOST } from '../utils/mocks/ollama.js'
+import { AZURE_DEPLOYMENT_NAME, AZURE_MOCK_HOST } from '../utils/mocks/azure.js'
 
 const expectedStreamBody = buildExpectedStreamBodyString()
 

--- a/tests/unit/generator.test.ts
+++ b/tests/unit/generator.test.ts
@@ -4,16 +4,16 @@ import assert from 'node:assert'
 import { existsSync } from 'node:fs'
 import { mkdir, rm, readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import AiWarpGenerator from '../../lib/generator'
-import { generateGlobalTypesFile } from '../../lib/templates/types'
-import { generatePluginWithTypesSupport } from '@platformatic/generators/lib/create-plugin'
+import AiWarpGenerator from '../../lib/generator.js'
+import { generateGlobalTypesFile } from '../../lib/templates/types.js'
+import { generatePluginWithTypesSupport } from '@platformatic/generators/lib/create-plugin.js'
 
-const tempDirBase = join(__dirname, 'tmp')
+const tempDirBase = join(import.meta.dirname, 'tmp')
 
 let counter = 0
 export async function getTempDir (baseDir: string): Promise<string> {
   if (baseDir === undefined) {
-    baseDir = __dirname
+    baseDir = import.meta.dirname
   }
   const dir = join(baseDir, `platformatic-generators-${process.pid}-${Date.now()}-${counter++}`)
   try {
@@ -39,7 +39,7 @@ describe('AiWarpGenerator', () => {
     const generator = new AiWarpGenerator()
     generator.setConfig({
       targetDirectory: dir,
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json'),
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json'),
       aiProvider: 'openai',
       aiModel: 'gpt-3.5-turbo'
     })
@@ -55,7 +55,7 @@ describe('AiWarpGenerator', () => {
     const generator = new AiWarpGenerator()
     generator.setConfig({
       targetDirectory: dir,
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json'),
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json'),
       aiProvider: 'openai',
       aiModel: 'gpt-3.5-turbo'
     })
@@ -77,7 +77,7 @@ describe('AiWarpGenerator', () => {
     const generator = new AiWarpGenerator()
     generator.setConfig({
       targetDirectory: dir,
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json'),
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json'),
       aiProvider: 'openai',
       aiModel: 'gpt-3.5-turbo'
     })
@@ -112,7 +112,7 @@ describe('AiWarpGenerator', () => {
     const generator = new AiWarpGenerator()
     generator.setConfig({
       targetDirectory: dir,
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json'),
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json'),
       aiProvider: 'openai',
       aiModel: 'gpt-3.5-turbo'
     })
@@ -128,7 +128,7 @@ describe('AiWarpGenerator', () => {
     const generator = new AiWarpGenerator()
     generator.setConfig({
       targetDirectory: dir,
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json'),
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json'),
       aiProvider: 'openai',
       aiModel: 'gpt-3.5-turbo',
       plugin: true
@@ -148,7 +148,7 @@ describe('AiWarpGenerator', () => {
     const generator = new AiWarpGenerator()
     generator.setConfig({
       targetDirectory: dir,
-      aiWarpPackageJsonPath: join(__dirname, '..', '..', 'package.json'),
+      aiWarpPackageJsonPath: join(import.meta.dirname, '..', '..', 'package.json'),
       aiProvider: 'openai',
       aiModel: 'gpt-3.5-turbo',
       plugin: true,

--- a/tests/unit/index.ts
+++ b/tests/unit/index.ts
@@ -1,5 +1,5 @@
 import './generator.test'
 import './ai-providers.test'
-import { mockAllProviders } from '../utils/mocks'
+import { mockAllProviders } from '../utils/mocks/index.js'
 
 mockAllProviders()

--- a/tests/utils/auth.ts
+++ b/tests/utils/auth.ts
@@ -1,5 +1,5 @@
 import { createSigner } from 'fast-jwt'
-import { AiWarpConfig } from '../../config'
+import { AiWarpConfig } from '../../config.js'
 
 export const authConfig: AiWarpConfig['auth'] = {
   required: true,

--- a/tests/utils/mocks/azure.ts
+++ b/tests/utils/mocks/azure.ts
@@ -1,5 +1,5 @@
 import { Server, createServer } from 'node:http'
-import { MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS } from './base'
+import { MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS } from './base.js'
 
 export const AZURE_MOCK_HOST = 'http://127.0.0.1:41435'
 

--- a/tests/utils/mocks/index.ts
+++ b/tests/utils/mocks/index.ts
@@ -1,8 +1,8 @@
 import { after } from 'node:test'
-import { mockAzure } from './azure'
-import { mockMistralApi } from './mistral'
-import { mockOllama } from './ollama'
-import { mockOpenAiApi } from './open-ai'
+import { mockAzure } from './azure.js'
+import { mockMistralApi } from './mistral.js'
+import { mockOllama } from './ollama.js'
+import { mockOpenAiApi } from './open-ai.js'
 
 export function mockAllProviders (): void {
   mockOpenAiApi()

--- a/tests/utils/mocks/mistral.ts
+++ b/tests/utils/mocks/mistral.ts
@@ -1,4 +1,4 @@
-import { MOCK_AGENT, MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS, establishMockAgent } from './base'
+import { MOCK_AGENT, MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS, establishMockAgent } from './base.js'
 
 let isMistralMocked = false
 
@@ -19,7 +19,7 @@ export function mockMistralApi (): void {
   pool.intercept({
     path: '/v1/chat/completions',
     method: 'POST'
-  }).reply(200, (opts) => {
+  }).reply(200, (opts: any) => {
     if (typeof opts.body !== 'string') {
       throw new Error(`body is not a string (${typeof opts.body})`)
     }

--- a/tests/utils/mocks/ollama.ts
+++ b/tests/utils/mocks/ollama.ts
@@ -1,4 +1,4 @@
-import { MOCK_AGENT, MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS, establishMockAgent } from './base'
+import { MOCK_AGENT, MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS, establishMockAgent } from './base.js'
 
 export const OLLAMA_MOCK_HOST = 'http://127.0.0.1:41434'
 let isOllamaMocked = false
@@ -19,7 +19,7 @@ export function mockOllama (): void {
   pool.intercept({
     path: '/api/chat',
     method: 'POST'
-  }).reply(200, (opts) => {
+  }).reply(200, (opts: any) => {
     if (typeof opts.body !== 'string') {
       throw new Error(`body is not a string (${typeof opts.body})`)
     }

--- a/tests/utils/mocks/open-ai.ts
+++ b/tests/utils/mocks/open-ai.ts
@@ -1,4 +1,4 @@
-import { MOCK_AGENT, MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS, establishMockAgent } from './base'
+import { MOCK_AGENT, MOCK_CONTENT_RESPONSE, MOCK_STREAMING_CONTENT_CHUNKS, establishMockAgent } from './base.js'
 
 let isOpenAiMocked = false
 
@@ -19,7 +19,7 @@ export function mockOpenAiApi (): void {
   pool.intercept({
     path: '/v1/chat/completions',
     method: 'POST'
-  }).reply(200, (opts) => {
+  }).reply(200, (opts: any) => {
     if (typeof opts.body !== 'string') {
       throw new Error(`body is not a string (${typeof opts.body})`)
     }

--- a/tests/utils/stackable.ts
+++ b/tests/utils/stackable.ts
@@ -1,7 +1,7 @@
 import { buildServer } from '@platformatic/service'
 import { FastifyInstance } from 'fastify'
-import stackable from '../../index'
-import { AiWarpConfig } from '../../config'
+import stackable from '../../index.js'
+import { AiWarpConfig } from '../../config.js'
 
 declare module 'fastify' {
   interface FastifyInstance {


### PR DESCRIPTION
This is to allow us to cleanup some of the logic for the AI providers (including most of the `// @ts-expect-error` comments) and allows us to mock imports (which we'll be using for llama2 support).

Unfortunately, with `module` and `moduleResolution` set to `NodeNext` in the tsconfig, we need to add .js extensions to relative imports. If we set `module` and `moduleResolution` to `ESNext`, this removes that requirement _at build time_. At runtime it will throw module not found errors because of the missing file extension. I haven't been able to find anything in the tsconfig that will add the file extensions for us either, and the next best solution would be to have some additional build step that goes into each file and adds the file extension. Regardless, it should be doable but I'm leaning towards this approach being better (although a bit ugly).