### PR TITLE
Simplify common dev commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Steps for downloading and setting up AI Warp for local development.
  6. Generate the test app.
 
     ```bash
-    node ./dist/cli/create.js
+    npm run create
     ```
 
  7. Configure the test app's `platformatic.json` to your liking. By default, it
@@ -41,7 +41,7 @@ Steps for downloading and setting up AI Warp for local development.
  8. Start the test app.
 
     ```bash
-    node ./dist/cli/start.js -c <path to test app platformatic.json>
+    npm start
     ```
 
 ## Important Notes
@@ -52,7 +52,7 @@ app. This includes schema changes.
 ## Noteable Commands
 
 * `npm run build` - Build the app.
-* `npm run build:config` - Rebuild the config. **Make sure to build first.**
+* `npm run build:config` - Rebuild the config.
 * `npm run lint:fix` - Fix all formatting issues and console log any linting
 issues that need to be fixed in code.
 * `npm run test` - Run Unit, E2E, and Type tests.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started using AI Warp, all you need to do is three steps:
     ```bash
     npm install
     npm run build
-    node ./dist/cli/create.js
+    npm run create
     ```
 
  2. Configure the app's Platformatic config file. By default, this is located
@@ -21,7 +21,7 @@ To get started using AI Warp, all you need to do is three steps:
  3. Start the app!
 
     ```bash
-    node ./dist/cli/start.js
+    npm start
     ```
 
 For more information, see [CONTRIBUTING.md](./CONTRIBUTING.md) and [Documentation](#documentation).

--- a/docs/add-ai-provider.md
+++ b/docs/add-ai-provider.md
@@ -5,7 +5,7 @@ Documentation on how to support a new AI provider.
 
 ### 1. Setup your developer environment
 
-See [Dev Setup](./dev-setup.md).
+See [CONTRIBUTING](../CONTRIBUTING.md).
 
 ### 2. Add it to the Config Schema
 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "start-ai-warp": "./dist/cli/start.js"
   },
   "scripts": {
+    "create": "node ./dist/cli/create.js",
+    "start": "node ./dist/cli/start.js -c ./ai-warp-app/platformatic.json",
     "build": "tsc --build && cp -r ./static ./dist/",
-    "build:config": "node ./dist/lib/schema.js --dump-schema | json2ts > config.d.ts",
+    "build:config": "npm run build && node ./dist/lib/schema.js --dump-schema | json2ts > config.d.ts",
     "clean": "rm -fr ./dist",
     "lint": "ts-standard | snazzy",
     "lint:fix": "ts-standard --fix | snazzy",


### PR DESCRIPTION
 * `npm run create` to create the test app
 * `npm start` to start the test app
 * `npm run build:config` automatically runs `npm run build` beforehand